### PR TITLE
fix(timeout): add provider-aware request timeout controls

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,7 @@ ai:
   model: "gpt-4o"
   max_tokens: 8192
   # timeout_seconds: 120  # optional; default is 1800 for ollama, 120 otherwise
+  # NOTE: DOCFORGE_TIMEOUT_SECONDS env var overrides ai.timeout_seconds at runtime.
 
 context:
   max_context_kb: 128

--- a/README.md
+++ b/README.md
@@ -61,6 +61,7 @@ ai:
   provider: "github"   # default — uses GITHUB_TOKEN automatically
   model: "gpt-4o"
   max_tokens: 8192
+  # timeout_seconds: 120  # optional; default is 1800 for ollama, 120 otherwise
 
 context:
   max_context_kb: 128

--- a/README.md
+++ b/README.md
@@ -85,6 +85,11 @@ output:
 
 See [`docforge.example.yml`](docforge.example.yml) for the fully-commented version.
 
+If `.docforge.yml` is missing, docforge falls back to built-in defaults
+(`provider: github`, `model: gpt-4o`) and requires `GITHUB_TOKEN`.
+To run with any non-default provider (for example `ollama`), create
+`.docforge.yml` (or pass an explicit config path).
+
 ---
 
 ## Supported LLM Providers

--- a/README.md
+++ b/README.md
@@ -86,8 +86,11 @@ output:
 
 See [`docforge.example.yml`](docforge.example.yml) for the fully-commented version.
 
-If `.docforge.yml` is missing, docforge falls back to built-in defaults
-(`provider: github`, `model: gpt-4o`) and requires `GITHUB_TOKEN`.
+When running `generate.py` locally without `--config`, if `.docforge.yml` is
+missing, docforge falls back to built-in defaults (`provider: github`,
+`model: gpt-4o`) and requires `GITHUB_TOKEN`.
+The GitHub Action defaults to `config: .docforge.yml`, so it will fail if that
+file is missing unless you override the action `config` input.
 To run with any non-default provider (for example `ollama`), create
 `.docforge.yml` (or pass an explicit config path).
 

--- a/docforge.example.yml
+++ b/docforge.example.yml
@@ -33,7 +33,7 @@ ai:
   # If omitted, docforge uses provider-aware defaults:
   #   - ollama: 1800 (30 min)
   #   - others: 120
-  # You can also override with env var DOCFORGE_TIMEOUT_SECONDS.
+  # Runtime override: DOCFORGE_TIMEOUT_SECONDS (env var) takes precedence.
   # timeout_seconds: 1800
 
   # base_url: ""          # Required only for provider: openai_compat (custom endpoint)

--- a/docforge.example.yml
+++ b/docforge.example.yml
@@ -29,6 +29,13 @@ ai:
   # Maximum tokens in the model response. Increase for very large codebases.
   max_tokens: 8192
 
+  # Per-request timeout in seconds.
+  # If omitted, docforge uses provider-aware defaults:
+  #   - ollama: 1800 (30 min)
+  #   - others: 120
+  # You can also override with env var DOCFORGE_TIMEOUT_SECONDS.
+  # timeout_seconds: 1800
+
   # base_url: ""          # Required only for provider: openai_compat (custom endpoint)
   # aws_region: "us-east-1"  # AWS Bedrock only
   # aws_profile: ""          # AWS Bedrock only (default credential chain if omitted)

--- a/docs/DOCKER.md
+++ b/docs/DOCKER.md
@@ -58,7 +58,7 @@ docker run --rm \
 
 ## Configuration
 
-### Option 1: Config file in the repository (recommended; required for non-default behavior)
+### Option 1: Config file in the repository (recommended; required for provider/model/prompt customization)
 
 Place `.docforge.yml` in your repository root:
 
@@ -122,7 +122,10 @@ You must provide a config file (in-repo or external via `CONFIG_FILE`) when you
 want anything non-default, for example:
 - `ai.provider: ollama`, `groq`, `anthropic`, `openrouter`, `together`, `bedrock`, or custom `openai_compat`
 - Non-default model selection
-- Custom `timeout_seconds`, context/output settings, or prompt paths
+- Custom context/output settings or prompt paths
+
+`DOCFORGE_TIMEOUT_SECONDS` is a runtime env override and can be used without
+editing `.docforge.yml`.
 
 ---
 

--- a/docs/DOCKER.md
+++ b/docs/DOCKER.md
@@ -21,6 +21,9 @@ docker run --rm \
 
 Docs appear in `./docs/`.
 
+This quick start uses the default provider (`github`), so `GITHUB_TOKEN` must
+be set in your environment.
+
 ---
 
 ## Image Tags
@@ -55,7 +58,7 @@ docker run --rm \
 
 ## Configuration
 
-### Option 1: Config file in the repository (recommended)
+### Option 1: Config file in the repository (recommended; required for non-default behavior)
 
 Place `.docforge.yml` in your repository root:
 
@@ -95,10 +98,10 @@ docker run --rm \
   ghcr.io/nikolareljin/docforge:latest
 ```
 
-### Option 3: Default config (no customization)
+### Option 3: Default config (no `.docforge.yml`)
 
 If no `.docforge.yml` exists, the image uses the built-in default config
-(`docforge.example.yml`). Set the project name via environment variables:
+(`docforge.example.yml`):
 
 ```bash
 docker run --rm \
@@ -108,7 +111,18 @@ docker run --rm \
   ghcr.io/nikolareljin/docforge:latest
 ```
 
-The default provider is `github` with model `gpt-4o`.
+Defaults in this mode:
+- Provider: `github`
+- Model: `gpt-4o`
+- Requirement: `GITHUB_TOKEN` must be set
+
+### When `.docforge.yml` is required
+
+You must provide a config file (in-repo or external via `CONFIG_FILE`) when you
+want anything non-default, for example:
+- `ai.provider: ollama`, `groq`, `anthropic`, `openrouter`, `together`, `bedrock`, or custom `openai_compat`
+- Non-default model selection
+- Custom `timeout_seconds`, context/output settings, or prompt paths
 
 ---
 
@@ -199,6 +213,9 @@ docker run --rm \
   -v "$(pwd)/docs:/output" \
   ghcr.io/nikolareljin/docforge:latest
 ```
+
+This requires `.docforge.yml` (or an external `CONFIG_FILE`) with
+`ai.provider: "ollama"`.
 
 Config file:
 

--- a/docs/DOCKER.md
+++ b/docs/DOCKER.md
@@ -148,7 +148,7 @@ For `ollama` (local) or `bedrock` (AWS), no key is needed.
 | `CONFIG_FILE` | `/repo/.docforge.yml` | Path to config file |
 | `REPO_PATH` | `/repo` | Repository root inside container |
 | `OUTPUT_DIR` | `/output` | Where to write docs inside container |
-| `DOCFORGE_TIMEOUT_SECONDS` | provider-dependent | Override LLM request timeout (default: `1800` for `ollama`, otherwise `120`) |
+| `DOCFORGE_TIMEOUT_SECONDS` | provider-dependent | Runtime override for request timeout (takes precedence over `ai.timeout_seconds`) |
 
 ---
 

--- a/docs/DOCKER.md
+++ b/docs/DOCKER.md
@@ -134,6 +134,7 @@ For `ollama` (local) or `bedrock` (AWS), no key is needed.
 | `CONFIG_FILE` | `/repo/.docforge.yml` | Path to config file |
 | `REPO_PATH` | `/repo` | Repository root inside container |
 | `OUTPUT_DIR` | `/output` | Where to write docs inside container |
+| `DOCFORGE_TIMEOUT_SECONDS` | provider-dependent | Override LLM request timeout (default: `1800` for `ollama`, otherwise `120`) |
 
 ---
 
@@ -205,9 +206,22 @@ Config file:
 ai:
   provider: "ollama"
   model: "qwen2.5:72b"
+  # Optional override. If omitted, ollama defaults to 1800s timeout.
+  timeout_seconds: 1800
 ```
 
 Ollama must be listening on `http://localhost:11434`.
+
+For very slow local models, you can also set a runtime override:
+
+```bash
+docker run --rm \
+  --network host \
+  -v "$(pwd):/repo:ro" \
+  -v "$(pwd)/docs:/output" \
+  -e DOCFORGE_TIMEOUT_SECONDS=3600 \
+  ghcr.io/nikolareljin/docforge:latest
+```
 
 ### AWS Bedrock
 

--- a/docs/USER_GUIDE.md
+++ b/docs/USER_GUIDE.md
@@ -76,6 +76,7 @@ ai:
   provider: "github"                   # Default — uses GITHUB_TOKEN automatically
   model: "gpt-4o"                      # Model to use
   max_tokens: 8192                     # Max response length
+  # timeout_seconds: 120               # Optional request timeout override
 
   # Other provider examples:
   # provider: "groq"
@@ -190,6 +191,7 @@ Run Ollama locally and point docforge at it:
 ai:
   provider: "ollama"
   model: "qwen2.5:72b"
+  # timeout_seconds: 1800              # Optional; ollama default is already 1800s
 ```
 
 No secrets needed. Run locally:

--- a/docs/USER_GUIDE.md
+++ b/docs/USER_GUIDE.md
@@ -194,6 +194,10 @@ ai:
   # timeout_seconds: 1800              # Optional; ollama default is already 1800s
 ```
 
+For one-off runs, you can override timeout without editing config:
+`DOCFORGE_TIMEOUT_SECONDS=3600 python vendor/docforge/generate.py --repo-path .`
+(`DOCFORGE_TIMEOUT_SECONDS` takes precedence over `ai.timeout_seconds`).
+
 No secrets needed. Run locally:
 
 ```bash

--- a/generate.py
+++ b/generate.py
@@ -120,15 +120,15 @@ def _resolve_timeout_seconds(ai_cfg: dict) -> int:
     """Resolve request timeout with provider-aware defaults.
 
     Precedence:
-    1. ai.timeout_seconds in config
-    2. DOCFORGE_TIMEOUT_SECONDS environment variable
+    1. DOCFORGE_TIMEOUT_SECONDS environment variable
+    2. ai.timeout_seconds in config
     3. Provider default (ollama: 1800s, others: 120s)
     """
-    raw_timeout = ai_cfg.get("timeout_seconds")
-    if raw_timeout is None:
-        env_timeout = os.environ.get("DOCFORGE_TIMEOUT_SECONDS", "").strip()
-        if env_timeout:
-            raw_timeout = env_timeout
+    env_timeout = os.environ.get("DOCFORGE_TIMEOUT_SECONDS", "").strip()
+    if env_timeout:
+        raw_timeout = env_timeout
+    else:
+        raw_timeout = ai_cfg.get("timeout_seconds")
 
     if raw_timeout is None:
         provider = str(ai_cfg.get("provider", "github")).strip().lower()

--- a/generate.py
+++ b/generate.py
@@ -149,8 +149,7 @@ def _resolve_timeout_seconds(ai_cfg: dict) -> tuple[int, str]:
 
     if timeout <= 0:
         print(
-            f"error: timeout from {source} must be greater than 0 "
-            f"(got {timeout}).",
+            f"error: timeout from {source} must be greater than 0 (got {timeout}).",
             file=sys.stderr,
         )
         sys.exit(1)

--- a/generate.py
+++ b/generate.py
@@ -116,7 +116,7 @@ def _log(msg: str) -> None:
     print(msg, flush=True)
 
 
-def _resolve_timeout_seconds(ai_cfg: dict) -> int:
+def _resolve_timeout_seconds(ai_cfg: dict) -> tuple[int, str]:
     """Resolve request timeout with provider-aware defaults.
 
     Precedence:
@@ -127,31 +127,35 @@ def _resolve_timeout_seconds(ai_cfg: dict) -> int:
     env_timeout = os.environ.get("DOCFORGE_TIMEOUT_SECONDS", "").strip()
     if env_timeout:
         raw_timeout = env_timeout
+        source = "DOCFORGE_TIMEOUT_SECONDS"
     else:
         raw_timeout = ai_cfg.get("timeout_seconds")
+        source = "ai.timeout_seconds"
 
     if raw_timeout is None:
         provider = str(ai_cfg.get("provider", "github")).strip().lower()
-        return 1800 if provider == "ollama" else 120
+        timeout = 1800 if provider == "ollama" else 120
+        return timeout, "provider default"
 
     try:
         timeout = int(raw_timeout)
     except (TypeError, ValueError):
         print(
-            "error: ai.timeout_seconds must be a positive integer "
-            "(or set DOCFORGE_TIMEOUT_SECONDS).",
+            f"error: invalid timeout from {source}: {raw_timeout!r}. "
+            "Expected a positive integer.",
             file=sys.stderr,
         )
         sys.exit(1)
 
     if timeout <= 0:
         print(
-            "error: ai.timeout_seconds must be greater than 0.",
+            f"error: timeout from {source} must be greater than 0 "
+            f"(got {timeout}).",
             file=sys.stderr,
         )
         sys.exit(1)
 
-    return timeout
+    return timeout, source
 
 
 def main() -> None:
@@ -242,8 +246,8 @@ def main() -> None:
     user_guide_text: str = ""
 
     ai_label = f"{ai_cfg.get('provider', 'github')} / {ai_cfg.get('model', 'gpt-4o')}"
-    request_timeout = _resolve_timeout_seconds(ai_cfg)
-    _log(f"[docforge] Request timeout: {request_timeout}s")
+    request_timeout, timeout_source = _resolve_timeout_seconds(ai_cfg)
+    _log(f"[docforge] Request timeout: {request_timeout}s ({timeout_source})")
 
     if generate in ("developer", "both"):
         prompt_path = _resolve_prompt_path(

--- a/generate.py
+++ b/generate.py
@@ -116,6 +116,44 @@ def _log(msg: str) -> None:
     print(msg, flush=True)
 
 
+def _resolve_timeout_seconds(ai_cfg: dict) -> int:
+    """Resolve request timeout with provider-aware defaults.
+
+    Precedence:
+    1. ai.timeout_seconds in config
+    2. DOCFORGE_TIMEOUT_SECONDS environment variable
+    3. Provider default (ollama: 1800s, others: 120s)
+    """
+    raw_timeout = ai_cfg.get("timeout_seconds")
+    if raw_timeout is None:
+        env_timeout = os.environ.get("DOCFORGE_TIMEOUT_SECONDS", "").strip()
+        if env_timeout:
+            raw_timeout = env_timeout
+
+    if raw_timeout is None:
+        provider = str(ai_cfg.get("provider", "github")).strip().lower()
+        return 1800 if provider == "ollama" else 120
+
+    try:
+        timeout = int(raw_timeout)
+    except (TypeError, ValueError):
+        print(
+            "error: ai.timeout_seconds must be a positive integer "
+            "(or set DOCFORGE_TIMEOUT_SECONDS).",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
+    if timeout <= 0:
+        print(
+            "error: ai.timeout_seconds must be greater than 0.",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
+    return timeout
+
+
 def main() -> None:
     parser = argparse.ArgumentParser(
         prog="docforge",
@@ -204,6 +242,8 @@ def main() -> None:
     user_guide_text: str = ""
 
     ai_label = f"{ai_cfg.get('provider', 'github')} / {ai_cfg.get('model', 'gpt-4o')}"
+    request_timeout = _resolve_timeout_seconds(ai_cfg)
+    _log(f"[docforge] Request timeout: {request_timeout}s")
 
     if generate in ("developer", "both"):
         prompt_path = _resolve_prompt_path(
@@ -211,7 +251,12 @@ def main() -> None:
             action_path,
         )
         _log(f"[docforge] Generating DEVELOPER.md ({ai_label})...")
-        result = gen.generate_from_prompt_file(prompt_path, context_text, action_path)
+        result = gen.generate_from_prompt_file(
+            prompt_path,
+            context_text,
+            action_path,
+            timeout=request_timeout,
+        )
         developer_text = result.text
         out = writer.write_developer(developer_text)
         _log(
@@ -224,7 +269,12 @@ def main() -> None:
             action_path,
         )
         _log(f"[docforge] Generating USER_GUIDE.md ({ai_label})...")
-        result = gen.generate_from_prompt_file(prompt_path, context_text, action_path)
+        result = gen.generate_from_prompt_file(
+            prompt_path,
+            context_text,
+            action_path,
+            timeout=request_timeout,
+        )
         user_guide_text = result.text
         out = writer.write_user_guide(user_guide_text)
         _log(

--- a/src/providers/anthropic.py
+++ b/src/providers/anthropic.py
@@ -15,6 +15,13 @@ _RETRY_STATUS_CODES = {429, 503, 529}
 _RETRY_DELAY_SECONDS = 10
 
 
+def _build_timeout(total_seconds: int) -> httpx.Timeout:
+    """Use a short connect timeout while preserving long read timeouts."""
+    total = float(total_seconds)
+    connect = min(10.0, max(1.0, total))
+    return httpx.Timeout(total, connect=connect)
+
+
 class AnthropicProvider(DocProvider):
     def __init__(self, api_key: str, model: str, max_tokens: int) -> None:
         self.api_key = api_key
@@ -22,6 +29,7 @@ class AnthropicProvider(DocProvider):
         self.max_tokens = max_tokens
 
     def generate(self, system: str, user: str, timeout: int = 120) -> DocResult:
+        timeout_cfg = _build_timeout(timeout)
         headers = {
             "x-api-key": self.api_key,
             "anthropic-version": _ANTHROPIC_VERSION,
@@ -41,7 +49,7 @@ class AnthropicProvider(DocProvider):
                     _ANTHROPIC_MESSAGES_URL,
                     headers=headers,
                     json=payload,
-                    timeout=timeout,
+                    timeout=timeout_cfg,
                 )
                 if response.status_code in _RETRY_STATUS_CODES and attempt == 0:
                     time.sleep(_RETRY_DELAY_SECONDS)

--- a/src/providers/anthropic.py
+++ b/src/providers/anthropic.py
@@ -7,19 +7,13 @@ import time
 import httpx
 
 from .base import DocProvider, DocResult
+from .http import build_timeout
 
 
 _ANTHROPIC_MESSAGES_URL = "https://api.anthropic.com/v1/messages"
 _ANTHROPIC_VERSION = "2023-06-01"
 _RETRY_STATUS_CODES = {429, 503, 529}
 _RETRY_DELAY_SECONDS = 10
-
-
-def _build_timeout(total_seconds: int) -> httpx.Timeout:
-    """Use a short connect timeout while preserving long read timeouts."""
-    total = float(total_seconds)
-    connect = min(10.0, max(1.0, total))
-    return httpx.Timeout(total, connect=connect)
 
 
 class AnthropicProvider(DocProvider):
@@ -29,7 +23,7 @@ class AnthropicProvider(DocProvider):
         self.max_tokens = max_tokens
 
     def generate(self, system: str, user: str, timeout: int = 120) -> DocResult:
-        timeout_cfg = _build_timeout(timeout)
+        timeout_cfg = build_timeout(timeout)
         headers = {
             "x-api-key": self.api_key,
             "anthropic-version": _ANTHROPIC_VERSION,

--- a/src/providers/http.py
+++ b/src/providers/http.py
@@ -1,0 +1,12 @@
+"""Shared HTTP utilities for provider integrations."""
+
+from __future__ import annotations
+
+import httpx
+
+
+def build_timeout(total_seconds: int) -> httpx.Timeout:
+    """Use a short connect timeout while preserving long read timeouts."""
+    total = float(total_seconds)
+    connect = min(10.0, max(1.0, total))
+    return httpx.Timeout(timeout=total, connect=connect)

--- a/src/providers/openai_compat.py
+++ b/src/providers/openai_compat.py
@@ -11,17 +11,11 @@ import time
 import httpx
 
 from .base import DocProvider, DocResult
+from .http import build_timeout
 
 
 _RETRY_STATUS_CODES = {429, 503, 529}
 _RETRY_DELAY_SECONDS = 10
-
-
-def _build_timeout(total_seconds: int) -> httpx.Timeout:
-    """Use a short connect timeout while preserving long read timeouts."""
-    total = float(total_seconds)
-    connect = min(10.0, max(1.0, total))
-    return httpx.Timeout(total, connect=connect)
 
 
 class OpenAICompatProvider(DocProvider):
@@ -39,7 +33,7 @@ class OpenAICompatProvider(DocProvider):
 
     def generate(self, system: str, user: str, timeout: int = 120) -> DocResult:
         url = f"{self.base_url}/chat/completions"
-        timeout_cfg = _build_timeout(timeout)
+        timeout_cfg = build_timeout(timeout)
         headers = {
             "Authorization": f"Bearer {self.api_key}",
             "content-type": "application/json",

--- a/src/providers/openai_compat.py
+++ b/src/providers/openai_compat.py
@@ -17,6 +17,13 @@ _RETRY_STATUS_CODES = {429, 503, 529}
 _RETRY_DELAY_SECONDS = 10
 
 
+def _build_timeout(total_seconds: int) -> httpx.Timeout:
+    """Use a short connect timeout while preserving long read timeouts."""
+    total = float(total_seconds)
+    connect = min(10.0, max(1.0, total))
+    return httpx.Timeout(total, connect=connect)
+
+
 class OpenAICompatProvider(DocProvider):
     def __init__(
         self,
@@ -32,6 +39,7 @@ class OpenAICompatProvider(DocProvider):
 
     def generate(self, system: str, user: str, timeout: int = 120) -> DocResult:
         url = f"{self.base_url}/chat/completions"
+        timeout_cfg = _build_timeout(timeout)
         headers = {
             "Authorization": f"Bearer {self.api_key}",
             "content-type": "application/json",
@@ -52,7 +60,7 @@ class OpenAICompatProvider(DocProvider):
                     url,
                     headers=headers,
                     json=payload,
-                    timeout=timeout,
+                    timeout=timeout_cfg,
                 )
                 if response.status_code in _RETRY_STATUS_CODES and attempt == 0:
                     time.sleep(_RETRY_DELAY_SECONDS)


### PR DESCRIPTION
- add ai.timeout_seconds and DOCFORGE_TIMEOUT_SECONDS override support

- use 1800s default for ollama and 120s for other providers

- document timeout tuning in README and Docker/User guides

Closes #1