### PR TITLE
Superseded: Add clone traffic chart

### DIFF
--- a/README.md
+++ b/README.md
@@ -201,3 +201,11 @@ See [`docs/USER_GUIDE.md`](docs/USER_GUIDE.md#notebooklm-auto-upload) for setup.
 ## License
 
 MIT
+
+---
+
+## Clone traffic
+
+![Clone traffic](https://raw.githubusercontent.com/nikolareljin/stats/main/charts/docforge.svg)
+
+_Updated daily. Total and unique cloners over the last 14 days._


### PR DESCRIPTION
## Summary

- Add the clone traffic SVG chart from nikolareljin/stats to the README.

## Validation

- Verified the stats SVG exists at charts/docforge.svg before updating the README.
- Ran git diff --check for the README change.