### PR TITLE
docs: add GitHub Pages product site

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ jobs:
           python-version: "3.11"
 
       - name: "Install ruff"
-        run: pip install --quiet ruff
+        run: pip install --quiet ruff==0.15.12
 
       - name: "ruff check"
         run: ruff check generate.py src/

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,0 +1,33 @@
+name: Pages
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "site/**"
+      - ".github/workflows/pages.yml"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: pages
+  cancel-in-progress: false
+
+jobs:
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/configure-pages@v5
+      - uses: actions/upload-pages-artifact@v3
+        with:
+          path: site
+      - id: deployment
+        uses: actions/deploy-pages@v4

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -25,9 +25,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/configure-pages@v5
-      - uses: actions/upload-pages-artifact@v4
+      - uses: actions/configure-pages@v6
+      - uses: actions/upload-pages-artifact@v5
         with:
           path: site
       - id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@v5

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -26,7 +26,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: actions/configure-pages@v5
-      - uses: actions/upload-pages-artifact@v3
+      - uses: actions/upload-pages-artifact@v4
         with:
           path: site
       - id: deployment

--- a/.github/workflows/pr-gate.yml
+++ b/.github/workflows/pr-gate.yml
@@ -12,7 +12,7 @@ jobs:
     uses: nikolareljin/ci-helpers/.github/workflows/pr-gate.yml@production
     with:
       python_version: "3.11"
-      install_command: "pip install --quiet ruff && sudo apt-get install -y --quiet shellcheck"
+      install_command: "pip install --quiet ruff==0.15.12 && sudo apt-get install -y --quiet shellcheck"
       lint_command: "ruff check generate.py src/ && ruff format --check generate.py src/ && shellcheck install.sh"
       test_command: ""
       build_command: ""

--- a/README.md
+++ b/README.md
@@ -1,11 +1,15 @@
 # docforge
 
+[![Website](https://img.shields.io/badge/docs-GitHub%20Pages-F5C451)](https://nikolareljin.github.io/docforge/)
+
 Auto-generate developer and end-user documentation from any codebase.
 Triggered by GitHub Actions on push to main/master. Output is optimized for
 [Google NotebookLM](https://notebooklm.google.com/) import.
 
 Designed to be vendored as a git submodule into any repository in your ecosystem.
 No API key secrets needed — the default provider uses `GITHUB_TOKEN` automatically.
+
+Project overview and quick start: <https://nikolareljin.github.io/docforge/>.
 
 ---
 

--- a/site/index.html
+++ b/site/index.html
@@ -1,0 +1,34 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Docforge — documentation generated with your code</title>
+  <meta name="description" content="Generate developer and end-user documentation from any codebase in GitHub Actions, with NotebookLM-ready output.">
+  <meta property="og:title" content="Docforge">
+  <meta property="og:description" content="Documentation generated with your code, not after it.">
+  <meta property="og:type" content="website">
+  <meta property="og:url" content="https://nikolareljin.github.io/docforge/">
+  <link rel="stylesheet" href="styles.css">
+</head>
+<body>
+<header class="topbar"><div class="wrap"><a class="brand" href="#top">nr/<span>docforge</span></a><nav aria-label="Primary navigation"><a href="#features">Features</a><a href="#install">Install</a><a class="optional" href="#providers">Providers</a><a href="https://github.com/nikolareljin/docforge">GitHub</a></nav></div></header>
+<main id="top">
+  <div class="hero wrap">
+    <p class="eyebrow">Standalone documentation automation</p>
+    <h1>Docs that move with the code.</h1>
+    <p class="lede">Vendor one GitHub Action into a repository and continuously generate a developer reference, an end-user guide, and a NotebookLM-ready source.</p>
+    <div class="actions"><a class="button primary" href="#install">Install Docforge</a><a class="button" href="https://github.com/nikolareljin/docforge/tree/main/docs">Read the guides</a></div>
+    <div class="signal" aria-label="Docforge highlights"><div><strong>two audiences</strong><span>Developer and end-user documentation stay separate.</span></div><div><strong>seven providers</strong><span>Choose hosted, local, or OpenAI-compatible models.</span></div><div><strong>one workflow</strong><span>Generation runs whenever the source changes.</span></div></div>
+  </div>
+  <section id="features"><div class="wrap"><div class="section-head"><p class="eyebrow">What it produces</p><h2>Useful output, already organized.</h2><p>Docforge inspects the repository context you select and writes predictable Markdown artifacts back to the project.</p></div><div class="grid"><article class="card"><h3>Developer reference</h3><p>Setup, architecture, APIs, extension points, configuration, and testing in <code>docs/DEVELOPER.md</code>.</p></article><article class="card"><h3>User guide</h3><p>Features, task-oriented instructions, examples, and troubleshooting in <code>docs/USER_GUIDE.md</code>.</p></article><article class="card"><h3>NotebookLM source</h3><p>A combined, attributed source in <code>docs/NOTEBOOKLM.md</code>, with optional direct upload.</p></article></div></div></section>
+  <section id="install"><div class="wrap"><div class="section-head"><p class="eyebrow">Quick install</p><h2>Add it from the project root.</h2><p>The installer adds Docforge as <code>vendor/docforge</code>, creates configuration, and installs the workflow.</p></div><div class="terminal"><div class="terminal-label">Terminal</div><pre><code>curl -fsSL https://raw.githubusercontent.com/nikolareljin/docforge/main/install.sh | bash
+
+# review generated configuration before committing
+git diff -- .gitmodules .docforge.yml .github/workflows/docs.yml</code></pre></div><p class="note">Review remote scripts before piping them to a shell. The <a href="https://github.com/nikolareljin/docforge#manual-install">manual submodule installation</a> provides the same result step by step.</p></div></section>
+  <section id="providers"><div class="wrap"><div class="section-head"><p class="eyebrow">Provider choice</p><h2>Hosted, local, or compatible.</h2><p>The default GitHub Models provider uses the workflow token. Other providers use their own secret or local endpoint.</p></div><div class="grid"><article class="card"><h3>Zero-secret default</h3><p>GitHub Models receives <code>GITHUB_TOKEN</code> automatically from the Actions runner.</p></article><article class="card"><h3>Hosted alternatives</h3><p>Use Groq, Anthropic, Together, OpenRouter, Bedrock, or an OpenAI-compatible endpoint.</p></article><article class="card"><h3>Local inference</h3><p>Choose Ollama for local runs where repository context must stay on your machine.</p></article></div></div></section>
+  <section id="ecosystem"><div class="wrap"><div class="section-head"><p class="eyebrow">Related tools</p><h2>Prefer a guided Claude Code workflow?</h2><p>Docforge is standalone automation—not a Claude Code plugin. Claude Docsmith provides an interactive, screenshot-aware documentation workflow inside Claude Code.</p></div><div class="grid"><article class="card suite-card"><span class="tag">Claude Code plugin</span><h3>Claude Docsmith</h3><p>Plan or write separate user and developer documentation with interactive review and optional local tooling.</p><a href="https://nikolareljin.github.io/claude-docsmith/">Explore Docsmith →</a></article><article class="card suite-card"><span class="tag">Plugin marketplace</span><h3>More Claude tools</h3><p>Browse security, documentation, and media plugins through one marketplace.</p><a href="https://nikolareljin.github.io/claude-plugins/">Visit the plugin suite →</a></article><article class="card"><h3>Detailed guides</h3><p>Configuration, Docker, multi-repository setup, NotebookLM, and internals live with the source.</p><a href="https://github.com/nikolareljin/docforge/tree/main/docs">Browse documentation →</a></article></div></div></section>
+</main>
+<footer><div class="wrap"><p>Docforge is standalone, MIT-licensed documentation automation.</p><div class="footer-links"><a href="https://github.com/nikolareljin/docforge">Repository</a><a href="https://github.com/nikolareljin/docforge/issues">Issues</a></div></div></footer>
+</body>
+</html>

--- a/site/styles.css
+++ b/site/styles.css
@@ -1,0 +1,35 @@
+:root {
+  --bg: #090b10; --surface: #111620; --surface-2: #171e2b; --text: #f4f7fb;
+  --muted: #a9b4c5; --line: #293446; --accent: #f5c451; --accent-2: #68d7ff;
+  --max: 74rem; --sans: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  --mono: "SFMono-Regular", Consolas, "Liberation Mono", monospace;
+}
+* { box-sizing: border-box; }
+html { color-scheme: dark; scroll-behavior: smooth; }
+body { margin: 0; background: var(--bg); color: var(--text); font: 1rem/1.65 var(--sans); }
+body::before { content: ""; position: fixed; inset: 0 0 auto; height: 34rem; pointer-events: none; z-index: -1; background: radial-gradient(circle at 20% 0, rgb(245 196 81 / 18%), transparent 52%), radial-gradient(circle at 85% 10%, rgb(104 215 255 / 12%), transparent 42%); }
+a { color: inherit; } a:focus-visible { outline: 3px solid var(--accent); outline-offset: 4px; border-radius: .2rem; }
+.wrap { width: min(var(--max), calc(100% - 2.5rem)); margin-inline: auto; }
+.topbar { position: sticky; top: 0; z-index: 10; border-bottom: 1px solid var(--line); background: rgb(9 11 16 / 88%); backdrop-filter: blur(14px); }
+.topbar .wrap { min-height: 4rem; display: flex; align-items: center; gap: 1.25rem; }
+.brand { font-weight: 800; text-decoration: none; letter-spacing: -.02em; } .brand span { color: var(--accent); }
+nav { margin-left: auto; display: flex; align-items: center; gap: 1.1rem; } nav a { color: var(--muted); text-decoration: none; font-size: .88rem; font-weight: 650; } nav a:hover { color: var(--text); }
+.hero { padding: clamp(4.5rem, 10vw, 8rem) 0 clamp(3.5rem, 8vw, 6rem); }
+.eyebrow { color: var(--accent); font: 700 .74rem/1 var(--mono); letter-spacing: .16em; text-transform: uppercase; }
+h1,h2,h3 { margin: 0; line-height: 1.08; letter-spacing: -.035em; } h1 { max-width: 14ch; margin-top: 1.2rem; font-size: clamp(2.7rem, 7vw, 6.2rem); } h2 { font-size: clamp(2rem, 4vw, 3.4rem); } h3 { font-size: 1.18rem; }
+.lede { max-width: 47rem; margin: 1.5rem 0 0; color: var(--muted); font-size: clamp(1.08rem, 2vw, 1.35rem); }
+.actions { display: flex; flex-wrap: wrap; gap: .75rem; margin-top: 2rem; }
+.button { display: inline-flex; align-items: center; justify-content: center; min-height: 2.9rem; padding: .65rem 1rem; border: 1px solid var(--line); border-radius: .55rem; text-decoration: none; font-weight: 750; } .button.primary { color: #101216; background: var(--accent); border-color: var(--accent); } .button:hover { border-color: var(--accent); }
+.signal { margin-top: 3rem; display: grid; grid-template-columns: repeat(3,1fr); gap: 1px; padding: 1px; background: var(--line); border-radius: .8rem; overflow: hidden; } .signal div { background: var(--surface); padding: 1.2rem; } .signal strong { display: block; color: var(--accent); font: 700 1rem var(--mono); } .signal span { color: var(--muted); font-size: .9rem; }
+section { padding: clamp(3.5rem, 7vw, 6rem) 0; border-top: 1px solid var(--line); } .section-head { max-width: 44rem; margin-bottom: 2rem; } .section-head p { color: var(--muted); }
+.grid { display: grid; grid-template-columns: repeat(3,minmax(0,1fr)); gap: 1rem; }
+.card { padding: 1.35rem; border: 1px solid var(--line); border-radius: .75rem; background: linear-gradient(145deg,var(--surface),var(--surface-2)); } .card p { margin-bottom: 0; color: var(--muted); } .card a { color: var(--accent-2); font-weight: 700; }
+.step { position: relative; padding-top: 3.25rem; } .step::before { content: attr(data-step); position: absolute; top: 1.2rem; color: var(--accent); font: 700 .8rem var(--mono); }
+.terminal { overflow: hidden; border: 1px solid var(--line); border-radius: .75rem; background: #07090d; } .terminal-label { padding: .65rem 1rem; border-bottom: 1px solid var(--line); color: var(--muted); font: 700 .7rem var(--mono); letter-spacing: .12em; text-transform: uppercase; }
+pre { margin: 0; padding: 1.2rem; overflow-x: auto; color: #dbe6f5; font: .88rem/1.8 var(--mono); } code { font-family: var(--mono); } p code,li code { padding: .12rem .3rem; border-radius: .25rem; background: var(--surface-2); color: #dbe6f5; }
+.note { margin-top: 1rem; padding-left: 1rem; border-left: 3px solid var(--accent); color: var(--muted); }
+.suite-card { display: flex; flex-direction: column; } .suite-card .tag { align-self: flex-start; margin-bottom: .8rem; color: var(--accent); font: 700 .68rem var(--mono); letter-spacing: .12em; text-transform: uppercase; } .suite-card p { flex: 1; }
+footer { padding: 2rem 0 3rem; border-top: 1px solid var(--line); color: var(--muted); } footer .wrap { display: flex; justify-content: space-between; gap: 1.5rem; } footer p { margin: 0; } .footer-links { display: flex; flex-wrap: wrap; gap: 1rem; }
+@media (max-width:52rem) { .grid,.signal { grid-template-columns: 1fr; } nav a.optional { display: none; } }
+@media (max-width:36rem) { .wrap { width: min(var(--max),calc(100% - 1.5rem)); } nav a:not(:last-child) { display:none; } footer .wrap { flex-direction:column; } }
+@media (prefers-reduced-motion:reduce) { html { scroll-behavior:auto; } }


### PR DESCRIPTION
## Summary
- add a responsive GitHub Pages product site
- document outputs, installation, providers, and NotebookLM support
- distinguish standalone Docforge from the related Claude Code plugin suite
- add ecosystem cross-links and a Pages deployment workflow

## Validation
- parsed `site/index.html` and verified local stylesheet
- `yamllint .github/workflows/pages.yml` (style warnings only: document start and GitHub Actions `on` key)
- `python3 -m pytest -q` (repository has no collected tests)
- `git diff --check`

## Pages activation
After merge, enable GitHub Pages with **GitHub Actions** as the source in repository settings.